### PR TITLE
fix: Changing code from ECMA6 to ECMA5

### DIFF
--- a/test/mocha.js
+++ b/test/mocha.js
@@ -76,14 +76,14 @@ describe('adm-zip', () => {
                 // It will actually create two, but the first is overwritten by the second.
             }
         });
-        let text = fs.readFileSync('./text.txt').toString()
+        var text = fs.readFileSync('./text.txt').toString()
         expect(text).to.equal('ride em cowboy!')
         fs.unlinkSync('./text.txt')
     })
 })
 
 function walk(dir) {
-    let results = [];
+    var results = [];
     const list = fs.readdirSync(dir);
     list.forEach(function (file) {
         file = dir + '/' + file;
@@ -100,7 +100,7 @@ function walk(dir) {
 }
 
 function walkD(dir) {
-    let results = [];
+    var results = [];
     const list = fs.readdirSync(dir);
     list.forEach(function (file) {
         file = dir + '/' + file;

--- a/zipFile.js
+++ b/zipFile.js
@@ -27,12 +27,12 @@ module.exports = function (/*String|Buffer*/input, /*Number*/inputType) {
 	}
 
 	function iterateEntries(callback) {
-		const totalEntries = mainHeader.diskEntries; // total number of entries
-		let index = mainHeader.offset; // offset of first CEN header
+		var totalEntries = mainHeader.diskEntries; // total number of entries
+		var index = mainHeader.offset; // offset of first CEN header
 
-		for (let i = 0; i < totalEntries; i++) {
-			let tmp = index;
-			const entry = new ZipEntry(inBuffer);
+		for (var i = 0; i < totalEntries; i++) {
+			var tmp = index;
+			var entry = new ZipEntry(inBuffer);
 
 			entry.header = inBuffer.slice(tmp, tmp += Utils.Constants.CENHDR);
 			entry.entryName = inBuffer.slice(tmp, tmp += entry.header.fileNameLength);
@@ -76,7 +76,7 @@ module.exports = function (/*String|Buffer*/input, /*Number*/inputType) {
 			n = max,
 			endStart = inBuffer.length,
 			endOffset = -1, // Start offset of the END header
-			commentEnd = 0; 
+			commentEnd = 0;
 
 		for (i; i >= n; i--) {
 			if (inBuffer[i] !== 0x50) continue; // quick check that the byte is 'P'


### PR DESCRIPTION
## Overview
We have to change the code from ECMA5 to ECMA6 because our tests were failing, as we are using Node v4.5.0 and it does not support ECMA6.